### PR TITLE
FIX: DAIA response with document element, but no item element(s)

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -513,7 +513,7 @@ class DAIA extends AbstractBase implements
                 $this->logMessages($docs["message"], "document");
             }
 
-            // do DAIA documents exist?
+            // do DAIA documents exist that have items?
             if (array_key_exists("document", $docs) && array_key_exists("item", $docs) && $this->multiQuery) {
                 // now loop through the found DAIA documents
                 foreach ($docs["document"] as $doc) {

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -514,7 +514,7 @@ class DAIA extends AbstractBase implements
             }
 
             // do DAIA documents exist?
-            if (array_key_exists("document", $docs) && $this->multiQuery) {
+            if (array_key_exists("document", $docs) && array_key_exists("item", $docs) && $this->multiQuery) {
                 // now loop through the found DAIA documents
                 foreach ($docs["document"] as $doc) {
                     // DAIA documents should use URIs as value for id
@@ -525,7 +525,7 @@ class DAIA extends AbstractBase implements
                         return $doc;
                     }
                 }
-            } elseif (array_key_exists("document", $docs)) {
+            } elseif (array_key_exists("document", $docs) && array_key_exists("item", $docs)) {
                 // since a document exists but multiQuery is disabled, the first
                 // document is returned
                 return array_shift($docs['document']);


### PR DESCRIPTION
If a DAIA response provides a document element, but no item element, then function extractDaiaDoc still adds the document to the docs array. This array is then later passed on to function parseDaiaDoc which in turn passes it on to function parseDaiaArray. parseDaiaArray only provides a valid return if at least one item element is present. This leads to an error "Notice: Undefined variable: result in ...\module\VuFind\src\VuFind\ILS\Driver\DAIA.php on line 675". A simple fix is to also to have extractDaiaDoc check whether the array key item exists. ... It might be even better to process the document somehow differently as it for example contains a href value with the link to the local OPAC system. Providing some information might be better then none...which also lead to having an empty holdings tab. However it might in the end be up to the individual developer to decide whether to show this kind of information or even filter these records, so they do not appear in the result list at all. For the purpose of the DAIA driver it might be ok just to make sure that no error message is being displayed in the user interface. Any thoughts?

Example of record with error notice: http://vufind.allegro-c.de:81/vufind241/Record/533208335
Example of DAIA response: http://daia.gbv.de/isil/DE-84/?id=ppn:533208335&format=xml
