### PR TITLE
FIX: Display of availability status information for holdings tab

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -690,7 +690,7 @@ class DAIA extends AbstractBase implements
     protected function getItemStatus($item)
     {
         $availability = false;
-        $status = ''; // status cannot be null as this will crash the translator
+        $status = 'Check catalogue for availability'; // initial status message, changed if available/unavailable information present
         $duedate = null;
         $availableLink = '';
         $queue = '';
@@ -740,6 +740,10 @@ class DAIA extends AbstractBase implements
                         ['loan', 'presentation', 'openaccess']
                     )
                 ) {
+		    // set item unavailable if service is loan, presentation or
+                    // openaccess
+                    $availability = false;
+                	
                     if ($unavailable['service'] == "loan"
                         && isset($unavailable['service']['href'])
                     ) {

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -710,6 +710,7 @@ class DAIA extends AbstractBase implements
                         // set item available if service is loan, presentation or
                         // openaccess
                         $availability = true;
+                        $status = 'Available';
                         if ($available['service'] == "loan"
                             && isset($available['service']['href'])
                         ) {
@@ -743,7 +744,7 @@ class DAIA extends AbstractBase implements
 		    // set item unavailable if service is loan, presentation or
                     // openaccess
                     $availability = false;
-                	
+		    $status='Checked Out';                	
                     if ($unavailable['service'] == "loan"
                         && isset($unavailable['service']['href'])
                     ) {

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -91,7 +91,7 @@
           <? else: ?>
             <? if ($row['availability']): ?>
               <? /* Begin Available Items (Holds) */ ?>
-               <span class="text-success"><?=$this->transEsc("Available")?><link property="availability" href="http://schema.org/InStock" /></span>
+               <span class="text-success"><?=$this->transEsc($row['status'])?><link property="availability" href="http://schema.org/InStock" /></span>
               <? if (isset($row['link']) && $row['link']): ?>
                 <a style="display:inline-block" class="<?=$check ? 'checkRequest ' : ''?>inlineblock modal-link placehold" href="<?=$this->recordLink()->getRequestUrl($row['link'])?>" title="<?=$this->transEsc($check ? "Check Hold" : "Place a Hold")?>"><i class="fa fa-flag"></i>&nbsp;<?=$this->transEsc($check ? "Check Hold" : "Place a Hold")?></a>
               <? endif; ?>


### PR DESCRIPTION
This addresses items that neither have available nor unavailable elements by introducing a default $status message. A fix was also required to the holdingsils.phtml so that limitations are displayed for available items as already done for unavailable items...to be consistent.
